### PR TITLE
Add @file context feature

### DIFF
--- a/src/sidekick/cli/repl.py
+++ b/src/sidekick/cli/repl.py
@@ -158,6 +158,15 @@ async def process_request(text: str, state_manager: StateManager, output: bool =
         True, state_manager.session.spinner, state_manager
     )
     try:
+        # Expand @file references before sending to the agent
+        try:
+            from sidekick.utils.text_utils import expand_file_refs
+
+            text = expand_file_refs(text)
+        except ValueError as e:
+            await ui.error(str(e))
+            return
+
         # Create a partial function that includes state_manager
         def tool_callback_with_state(part, node):
             return _tool_handler(part, node, state_manager)

--- a/src/sidekick/utils/text_utils.py
+++ b/src/sidekick/utils/text_utils.py
@@ -48,3 +48,40 @@ def ext_to_lang(path: str) -> str:
     if ext in MAP:
         return MAP[ext]
     return "text"
+
+
+def expand_file_refs(text: str) -> str:
+    """Expand @file references with file contents wrapped in code fences.
+
+    Args:
+        text: The input text potentially containing @file references.
+
+    Returns:
+        Text with any @file references replaced by the file's contents.
+
+    Raises:
+        ValueError: If a referenced file does not exist or is too large.
+    """
+    import os
+    import re
+
+    from sidekick.constants import (ERROR_FILE_NOT_FOUND, ERROR_FILE_TOO_LARGE, MAX_FILE_SIZE,
+                                    MSG_FILE_SIZE_LIMIT)
+
+    pattern = re.compile(r"@([\w./_-]+)")
+
+    def replacer(match: re.Match) -> str:
+        path = match.group(1)
+        if not os.path.exists(path):
+            raise ValueError(ERROR_FILE_NOT_FOUND.format(filepath=path))
+
+        if os.path.getsize(path) > MAX_FILE_SIZE:
+            raise ValueError(ERROR_FILE_TOO_LARGE.format(filepath=path) + MSG_FILE_SIZE_LIMIT)
+
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        lang = ext_to_lang(path)
+        return f"```{lang}\n{content}\n```"
+
+    return pattern.sub(replacer, text)


### PR DESCRIPTION
## Summary
- support using `@file` references in messages
- expand file references with actual file contents in a code block
- handle errors when files are missing or too large

## Testing
- `make lint` *(fails: flake8 not found)*
- `make test` *(fails: no tests collected)*